### PR TITLE
Change currentLanguage to pre-defined 'en-US'

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -16,7 +16,7 @@
         VERSION = '1.5.3',
         // internal storage for language config files
         languages = {},
-        currentLanguage = 'en',
+        currentLanguage = 'en-US',
         zeroFormat = null,
         defaultFormat = '0,0',
         defaultCurrencyFormat = '0$',


### PR DESCRIPTION
Or it might thow error below:

```
TypeError: Cannot read property 'delimiters' of undefined
    at formatNumber (numeral/numeral.js:469:102)
```